### PR TITLE
Add CLI for licensify key and PASERK management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
   (`k4.secret*`, `k4.public`) values, deriving and exporting symmetric keys,
   sealing secrets, and producing compliant Argon2 salts. The CLI outputs JSON by
   default and can be installed globally via `dart pub global activate licensify`.
+- **File-based CLI I/O**: Added `-i/--input` for reading PASERK material from
+  files (plain text or prior CLI JSON output) and `-o/--output` for writing the
+  generated JSON payload to disk without manual redirection.
 
 ## [4.0.0] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ All notable changes to this project will be documented in this file.
 - Password-wrapped outputs now surface the Argon2 salt (`passwordSalt`) and
   cost parameters so `--password` workflows automatically capture everything
   required for future recovery.
-- Fixed `licensify symmetric derive` so it honors PASERK Argon2 memory-cost
-  values, ensuring derived keys match previously wrapped outputs when restored
-  with the recorded password + salt.
+- Fixed `licensify symmetric derive` to convert PASERK Argon2 memory-cost
+  values from bytes to kibibytes before invoking the underlying implementation,
+  preserving compatibility with wrapped outputs and preventing Argon2 crashes
+  when deriving keys from passwords.
 
 ## [4.0.0] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ All notable changes to this project will be documented in this file.
   subcommand (e.g., `licensify symmetric -h`).
 - Listing help for `keypair`, `symmetric`, or `salt` now includes their
   respective subcommands to make discovery easier.
-- Password-wrapped outputs now surface the Argon2 salt (`passwordSalt`) and
-  cost parameters so `--password` workflows automatically capture everything
-  required for future recovery.
+- Password-wrapped outputs now surface the Argon2 salt and cost parameters
+  under `passwordWrap*` keys, while derivation commands label their explicit
+  salt and Argon2 inputs with `derive*` fields so JSON exports are easier to
+  interpret and persist.
 - Fixed `licensify symmetric derive` to convert PASERK Argon2 memory-cost
   values from bytes to kibibytes before invoking the underlying implementation,
   preserving compatibility with wrapped outputs and preventing Argon2 crashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
   subcommand (e.g., `licensify symmetric -h`).
 - Listing help for `keypair`, `symmetric`, or `salt` now includes their
   respective subcommands to make discovery easier.
+- Password-wrapped outputs now surface the Argon2 salt (`passwordSalt`) and
+  cost parameters so `--password` workflows automatically capture everything
+  required for future recovery.
 
 ## [4.0.0] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- No unreleased changes yet.
+
+## [4.1.0] - 2025-10-12
+
 ### ✨ New Features
 
 - **CLI for key management**: Introduced a `licensify` command-line tool with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### 🧰 Tooling
-
-- Improved the CLI help system so `-h/--help` works on every command and
-  subcommand (e.g., `licensify symmetric -h`).
+- No changes yet.
 
 ## [4.1.0] - 2025-10-12
 
@@ -21,6 +18,13 @@ All notable changes to this project will be documented in this file.
 - **File-based CLI I/O**: Added `-i/--input` for reading PASERK material from
   files (plain text or prior CLI JSON output) and `-o/--output` for writing the
   generated JSON payload to disk without manual redirection.
+
+### 🧰 Tooling
+
+- Improved the CLI help system so `-h/--help` works on every command and
+  subcommand (e.g., `licensify symmetric -h`).
+- Listing help for `keypair`, `symmetric`, or `salt` now includes their
+  respective subcommands to make discovery easier.
 
 ## [4.0.0] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project will be documented in this file.
 - Password-wrapped outputs now surface the Argon2 salt (`passwordSalt`) and
   cost parameters so `--password` workflows automatically capture everything
   required for future recovery.
+- Fixed `licensify symmetric derive` so it honors PASERK Argon2 memory-cost
+  values, ensuring derived keys match previously wrapped outputs when restored
+  with the recorded password + salt.
 
 ## [4.0.0] - 2025-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- No unreleased changes yet.
+### 🧰 Tooling
+
+- Improved the CLI help system so `-h/--help` works on every command and
+  subcommand (e.g., `licensify symmetric -h`).
 
 ## [4.1.0] - 2025-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### ✨ New Features
+
+- **CLI for key management**: Introduced a `licensify` command-line tool with
+  subcommands for generating Ed25519 key pairs, minting and converting PASERK
+  (`k4.secret*`, `k4.public`) values, deriving and exporting symmetric keys,
+  sealing secrets, and producing compliant Argon2 salts. The CLI outputs JSON by
+  default and can be installed globally via `dart pub global activate licensify`.
+
 ## [4.0.0] - 2025-09-20
 
 ### ⚠️ Breaking Changes

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ licensify --help
 All commands output JSON (pretty-printed by default, disable with `--no-pretty`).
 Use `-o/--output` to write the JSON response to a file and `-i/--input` to
 reuse PASERK strings (plain text) or previously exported JSON when invoking
-other commands.
+other commands. You can append `-h/--help` to any command or subcommand to see
+its dedicated usage, for example `licensify symmetric -h` or
+`licensify symmetric generate -h`.
 
 ```bash
 # Persist generated keys and inspect them later without copy/paste.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Licensify is a Dart library for issuing and validating software licenses backed 
 ## Contents
 - [Overview](#overview)
 - [Key capabilities](#key-capabilities)
+- [Command-line interface](#command-line-interface)
 - [Quick start](#quick-start)
 - [Data encryption](#data-encryption)
 - [Key lifecycle requirements](#key-lifecycle-requirements)
@@ -34,6 +35,48 @@ Licensify encapsulates key generation, license issuance, validation, and symmetr
 - Asynchronous API surfaces for IO-bound cryptographic operations.
 - Deterministic exceptions for malformed tokens and unsupported payloads.
 - Memory management helpers to ensure explicit key disposal.
+
+## Command-line interface
+
+The package ships with a dedicated CLI that streamlines key management and PASERK
+conversions without requiring you to write any Dart code. You can run it with
+`dart run bin/licensify.dart ...` inside the repository, or install it globally:
+
+```bash
+dart pub global activate licensify
+licensify --help
+```
+
+### Available commands
+
+| Command | Description |
+| --- | --- |
+| `keypair generate` | Mint a new Ed25519 signing key pair and emit PASERK `k4.secret`, `k4.secret-pw`, `k4.secret-wrap.pie`, and identifiers. |
+| `keypair info` | Inspect existing PASERK material (`k4.secret*`, `k4.public`) and re-export it in other formats. |
+| `symmetric generate` | Create an XChaCha20 encryption key and export `k4.local`, `k4.local-pw`, `k4.local-wrap.pie`, and optional sealed copies. |
+| `symmetric info` | Decode password-protected, wrapped, or sealed symmetric keys and convert them to other PASERK encodings. |
+| `symmetric derive` | Derive an encryption key from a password + salt using Argon2id with configurable parameters. |
+| `salt generate` | Produce base64url salts that satisfy PASERK `k4.local-pw` requirements. |
+
+All commands output JSON (pretty-printed by default, disable with `--no-pretty`).
+
+### Example
+
+```bash
+$ licensify keypair generate --password "correct horse battery staple"
+{
+  "type": "ed25519-keypair",
+  "publicKeyPaserk": "k4.public...",
+  "publicKeyId": "k4.pid...",
+  "paserkSecret": "k4.secret...",
+  "secretId": "k4.sid...",
+  "paserkSecretPw": "k4.secret-pw..."
+}
+```
+
+Use `licensify symmetric info --paserk <value>` to unwrap `k4.local-pw`,
+`k4.local-wrap.pie`, or `k4.seal` payloads by providing the required password
+or companion keys via flags.
 
 ## Quick start
 ### Generate signing keys and create a license

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ licensify --help
 | `salt generate` | Produce base64url salts that satisfy PASERK `k4.local-pw` requirements. |
 
 All commands output JSON (pretty-printed by default, disable with `--no-pretty`).
+Use `-o/--output` to write the JSON response to a file and `-i/--input` to
+reuse PASERK strings (plain text) or previously exported JSON when invoking
+other commands.
+
+```bash
+# Persist generated keys and inspect them later without copy/paste.
+licensify keypair generate -o secrets/signing.json
+licensify keypair info -i secrets/signing.json
+```
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,22 @@ $ licensify keypair generate --password "correct horse battery staple"
   "publicKeyId": "k4.pid...",
   "paserkSecret": "k4.secret...",
   "secretId": "k4.sid...",
-  "paserkSecretPw": "k4.secret-pw..."
+  "paserkSecretPw": "k4.secret-pw...",
+  "salt": "base64url-salt...",
+  "passwordSalt": "base64url-salt...",
+  "passwordMemoryCost": 67108864,
+  "passwordTimeCost": 3,
+  "passwordParallelism": 1
 }
 ```
+
+Whenever you request a password-protected export (`--password`), the CLI also
+records the Argon2 salt and cost parameters under the `password*` keys. Persist
+these values alongside the PASERK string so the key can be restored later with
+`licensify symmetric derive` or the equivalent library helpers. The top-level
+`salt` field continues to reflect the command-specific salt (for example, the
+input supplied to `symmetric derive`), while `passwordSalt` mirrors the value
+embedded inside the emitted `k4.*-pw` string.
 
 Use `licensify symmetric info --paserk <value>` to unwrap `k4.local-pw`,
 `k4.local-wrap.pie`, or `k4.seal` payloads by providing the required password

--- a/README.md
+++ b/README.md
@@ -96,24 +96,24 @@ $ licensify keypair generate --password "correct horse battery staple"
   "type": "ed25519-keypair",
   "publicKeyPaserk": "k4.public...",
   "publicKeyId": "k4.pid...",
-  "paserkSecret": "k4.secret...",
-  "secretId": "k4.sid...",
-  "paserkSecretPw": "k4.secret-pw...",
-  "salt": "base64url-salt...",
-  "passwordSalt": "base64url-salt...",
-  "passwordMemoryCost": 67108864,
-  "passwordTimeCost": 3,
-  "passwordParallelism": 1
+  "secretKeyPaserk": "k4.secret...",
+  "secretKeyId": "k4.sid...",
+  "passwordWrappedSecretKey": "k4.secret-pw...",
+  "passwordWrapSalt": "base64url-salt...",
+  "passwordWrapMemoryCost": 67108864,
+  "passwordWrapTimeCost": 3,
+  "passwordWrapParallelism": 1
 }
 ```
 
 Whenever you request a password-protected export (`--password`), the CLI also
-records the Argon2 salt and cost parameters under the `password*` keys. Persist
-these values alongside the PASERK string so the key can be restored later with
-`licensify symmetric derive` or the equivalent library helpers. The top-level
-`salt` field continues to reflect the command-specific salt (for example, the
-input supplied to `symmetric derive`), while `passwordSalt` mirrors the value
-embedded inside the emitted `k4.*-pw` string.
+records the Argon2 salt and cost parameters under the `passwordWrap*` keys.
+Persist these values alongside the PASERK string so the key can be restored
+later with `licensify symmetric derive` or the equivalent library helpers. When
+deriving symmetric material, the CLI also returns `derive*` keys that describe
+the salt and cost settings you provided explicitly, while the
+`passwordWrap*` keys mirror the values encoded inside the emitted `k4.*-pw`
+string.
 
 Use `licensify symmetric info --paserk <value>` to unwrap `k4.local-pw`,
 `k4.local-wrap.pie`, or `k4.seal` payloads by providing the required password

--- a/README.md
+++ b/README.md
@@ -63,7 +63,24 @@ Use `-o/--output` to write the JSON response to a file and `-i/--input` to
 reuse PASERK strings (plain text) or previously exported JSON when invoking
 other commands. You can append `-h/--help` to any command or subcommand to see
 its dedicated usage, for example `licensify symmetric -h` or
-`licensify symmetric generate -h`.
+`licensify symmetric generate -h`. The command-level help now lists the
+available subcommands so you can quickly discover what each area supports:
+
+```bash
+$ licensify symmetric -h
+Usage: licensify symmetric <subcommand> [arguments]
+
+Global options:
+-h, --help    Show usage information.
+
+Subcommands:
+  generate  Create a new symmetric key with PASERK exports
+  info      Decode or convert existing symmetric keys
+  derive    Derive a key from a password and salt
+```
+
+The same pattern works for `licensify keypair -h` and `licensify salt -h` to
+see their focused command lists.
 
 ```bash
 # Persist generated keys and inspect them later without copy/paste.

--- a/bin/licensify.dart
+++ b/bin/licensify.dart
@@ -18,6 +18,27 @@ ArgParser _parserWithHelp() => ArgParser()
     help: 'Show usage information.',
   );
 
+const Map<String, String> _rootCommandDescriptions = <String, String>{
+  'keypair': 'Manage Ed25519 signing key material',
+  'symmetric': 'Manage XChaCha20 encryption keys',
+  'salt': 'Generate Argon2id salts',
+};
+
+const Map<String, String> _keypairCommandDescriptions = <String, String>{
+  'generate': 'Mint a new Ed25519 signing key pair',
+  'info': 'Inspect or convert existing key material',
+};
+
+const Map<String, String> _symmetricCommandDescriptions = <String, String>{
+  'generate': 'Create a new symmetric key with PASERK exports',
+  'info': 'Decode or convert existing symmetric keys',
+  'derive': 'Derive a key from a password and salt',
+};
+
+const Map<String, String> _saltCommandDescriptions = <String, String>{
+  'generate': 'Produce base64url salts for Argon2id',
+};
+
 final ArgParser _keypairGenerateParser = _parserWithHelp()
   ..addOption(
     'password',
@@ -987,6 +1008,30 @@ List<String> _commandPathFrom(ArgResults command) {
   return path;
 }
 
+void _writeCommandTable(
+  Map<String, String> commands, {
+  required String heading,
+}) {
+  if (commands.isEmpty) {
+    return;
+  }
+
+  stderr.writeln(heading);
+  int maxNameLength = 0;
+  for (final String name in commands.keys) {
+    if (name.length > maxNameLength) {
+      maxNameLength = name.length;
+    }
+  }
+
+  for (final MapEntry<String, String> entry in commands.entries) {
+    final String name = entry.key;
+    final String description = entry.value;
+    final String padding = ' ' * (maxNameLength - name.length + 2);
+    stderr.writeln('  $name$padding$description');
+  }
+}
+
 void _printUsage(List<String> commandPath, {String? error}) {
   if (error != null) {
     stderr.writeln('Error: $error');
@@ -998,10 +1043,7 @@ void _printUsage(List<String> commandPath, {String? error}) {
     stderr.writeln('');
     stderr.writeln(_rootParser.usage);
     stderr.writeln('');
-    stderr.writeln('Commands:');
-    stderr.writeln('  keypair     Manage Ed25519 signing key material');
-    stderr.writeln('  symmetric   Manage XChaCha20 encryption keys');
-    stderr.writeln('  salt        Generate Argon2id salts');
+    _writeCommandTable(_rootCommandDescriptions, heading: 'Commands:');
     return;
   }
 
@@ -1011,6 +1053,11 @@ void _printUsage(List<String> commandPath, {String? error}) {
       stderr.writeln('Usage: licensify keypair <subcommand> [arguments]');
       stderr.writeln('');
       stderr.writeln(_keypairParser.usage);
+      stderr.writeln('');
+      _writeCommandTable(
+        _keypairCommandDescriptions,
+        heading: 'Subcommands:',
+      );
       if (commandPath.length > 1) {
         final String sub = commandPath[1];
         final ArgParser? subParser = _keypairParser.commands[sub];
@@ -1024,6 +1071,11 @@ void _printUsage(List<String> commandPath, {String? error}) {
       stderr.writeln('Usage: licensify symmetric <subcommand> [arguments]');
       stderr.writeln('');
       stderr.writeln(_symmetricParser.usage);
+      stderr.writeln('');
+      _writeCommandTable(
+        _symmetricCommandDescriptions,
+        heading: 'Subcommands:',
+      );
       if (commandPath.length > 1) {
         final String sub = commandPath[1];
         final ArgParser? subParser = _symmetricParser.commands[sub];
@@ -1037,6 +1089,11 @@ void _printUsage(List<String> commandPath, {String? error}) {
       stderr.writeln('Usage: licensify salt <subcommand> [arguments]');
       stderr.writeln('');
       stderr.writeln(_saltParser.usage);
+      stderr.writeln('');
+      _writeCommandTable(
+        _saltCommandDescriptions,
+        heading: 'Subcommands:',
+      );
       if (commandPath.length > 1) {
         final String sub = commandPath[1];
         final ArgParser? subParser = _saltParser.commands[sub];

--- a/bin/licensify.dart
+++ b/bin/licensify.dart
@@ -125,8 +125,7 @@ final ArgParser _symmetricDeriveParser = _parserWithHelp()
   ..addOption(
     'memory-cost',
     defaultsTo: K4LocalPw.defaultMemoryCost.toString(),
-    help:
-        'Argon2 memory cost in kibibytes (must be a positive multiple of 1024).',
+    help: 'Argon2 memory cost in bytes (must be a positive multiple of 1024).',
   )
   ..addOption(
     'time-cost',

--- a/bin/licensify.dart
+++ b/bin/licensify.dart
@@ -347,26 +347,27 @@ Future<void> _handleKeypairGenerate(
       'type': 'ed25519-keypair',
       'publicKeyPaserk': pair.publicKey.toPaserk(),
       'publicKeyId': pair.publicKey.toPaserkIdentifier(),
-      'paserkSecret': pair.toPaserkSecret(),
-      'secretId': pair.toPaserkSecretIdentifier(),
+      'secretKeyPaserk': pair.toPaserkSecret(),
+      'secretKeyId': pair.toPaserkSecretIdentifier(),
     };
 
     if (password != null && password.isNotEmpty) {
-      final String paserkSecretPw = await pair.toPaserkSecretPassword(
+      final String passwordWrappedSecret = await pair.toPaserkSecretPassword(
         password: password,
       );
-      output['paserkSecretPw'] = paserkSecretPw;
+      output['passwordWrappedSecretKey'] = passwordWrappedSecret;
       _applyPasswordMetadata(
         output,
         _parsePaserkPasswordMetadata(
-          paserkSecretPw,
+          passwordWrappedSecret,
           ['keypair', 'generate'],
         ),
+        prefix: 'passwordWrap',
       );
     }
 
     if (wrappingKey != null) {
-      output['paserkSecretWrap'] = pair.toPaserkSecretWrap(
+      output['wrappedSecretKeyPaserk'] = pair.toPaserkSecretWrap(
         wrappingKey: wrappingKey,
       );
     }
@@ -392,9 +393,9 @@ Future<void> _handleKeypairInfo(
 
   final String? paserkInput = _trimmedValue(args['paserk']) ??
       _paserkFromInput(fileInput, const [
-        'paserkSecret',
-        'paserkSecretPw',
-        'paserkSecretWrap',
+        'secretKeyPaserk',
+        'passwordWrappedSecretKey',
+        'wrappedSecretKeyPaserk',
         'publicKeyPaserk',
       ]);
   if (paserkInput == null || paserkInput.isEmpty) {
@@ -463,36 +464,38 @@ Future<void> _handleKeypairInfo(
       'sourceFormat': _detectKeyPairFormat(paserk),
       'publicKeyPaserk': pair.publicKey.toPaserk(),
       'publicKeyId': pair.publicKey.toPaserkIdentifier(),
-      'paserkSecret': pair.toPaserkSecret(),
-      'secretId': pair.toPaserkSecretIdentifier(),
+      'secretKeyPaserk': pair.toPaserkSecret(),
+      'secretKeyId': pair.toPaserkSecretIdentifier(),
     };
 
     if (password != null && password.isNotEmpty) {
-      final String paserkSecretPw = await pair.toPaserkSecretPassword(
+      final String passwordWrappedSecret = await pair.toPaserkSecretPassword(
         password: password,
       );
-      output['paserkSecretPw'] = paserkSecretPw;
+      output['passwordWrappedSecretKey'] = passwordWrappedSecret;
       _applyPasswordMetadata(
         output,
         _parsePaserkPasswordMetadata(
-          paserkSecretPw,
+          passwordWrappedSecret,
           ['keypair', 'info'],
         ),
+        prefix: 'passwordWrap',
       );
     } else if (paserk.startsWith('k4.secret-pw')) {
-      output['paserkSecretPw'] = paserk;
+      output['passwordWrappedSecretKey'] = paserk;
       _applyPasswordMetadata(
         output,
         _parsePaserkPasswordMetadata(paserk, ['keypair', 'info']),
+        prefix: 'passwordWrap',
       );
     }
 
     if (wrappingKey != null) {
-      output['paserkSecretWrap'] = pair.toPaserkSecretWrap(
+      output['wrappedSecretKeyPaserk'] = pair.toPaserkSecretWrap(
         wrappingKey: wrappingKey,
       );
     } else if (paserk.startsWith('k4.secret-wrap')) {
-      output['paserkSecretWrap'] = paserk;
+      output['wrappedSecretKeyPaserk'] = paserk;
     }
 
     await _printJson(output, pretty: pretty, outputPath: outputPath);
@@ -533,29 +536,32 @@ Future<void> _handleSymmetricGenerate(
   try {
     final Map<String, Object?> output = {
       'type': 'xchacha20-key',
-      'paserkLocal': key.toPaserk(),
-      'localId': key.toPaserkIdentifier(),
+      'localKeyPaserk': key.toPaserk(),
+      'localKeyId': key.toPaserkIdentifier(),
     };
 
     if (password != null && password.isNotEmpty) {
-      final String paserkLocalPw =
+      final String passwordWrappedLocal =
           await key.toPaserkPassword(password: password);
-      output['paserkLocalPw'] = paserkLocalPw;
+      output['passwordWrappedLocalKey'] = passwordWrappedLocal;
       _applyPasswordMetadata(
         output,
         _parsePaserkPasswordMetadata(
-          paserkLocalPw,
+          passwordWrappedLocal,
           ['symmetric', 'generate'],
         ),
+        prefix: 'passwordWrap',
       );
     }
 
     if (wrappingKey != null) {
-      output['paserkLocalWrap'] = key.toPaserkWrap(wrappingKey: wrappingKey);
+      output['wrappedLocalKeyPaserk'] =
+          key.toPaserkWrap(wrappingKey: wrappingKey);
     }
 
     if (sealingKey != null) {
-      output['paserkSeal'] = await key.toPaserkSeal(publicKey: sealingKey);
+      output['sealedLocalKeyPaserk'] =
+          await key.toPaserkSeal(publicKey: sealingKey);
     }
 
     await _printJson(output, pretty: pretty, outputPath: outputPath);
@@ -579,10 +585,10 @@ Future<void> _handleSymmetricInfo(
 
   final String? paserkInput = _trimmedValue(args['paserk']) ??
       _paserkFromInput(fileInput, const [
-        'paserkLocal',
-        'paserkLocalPw',
-        'paserkLocalWrap',
-        'paserkSeal',
+        'localKeyPaserk',
+        'passwordWrappedLocalKey',
+        'wrappedLocalKeyPaserk',
+        'sealedLocalKeyPaserk',
       ]);
   if (paserkInput == null || paserkInput.isEmpty) {
     throw _CliUsageException('Provide --paserk with a PASERK string.', ['symmetric', 'info']);
@@ -654,39 +660,43 @@ Future<void> _handleSymmetricInfo(
     final Map<String, Object?> output = {
       'type': 'xchacha20-key',
       'sourceFormat': _detectSymmetricFormat(paserk),
-      'paserkLocal': key.toPaserk(),
-      'localId': key.toPaserkIdentifier(),
+      'localKeyPaserk': key.toPaserk(),
+      'localKeyId': key.toPaserkIdentifier(),
     };
 
     if (password != null && password.isNotEmpty) {
-      final String paserkLocalPw =
+      final String passwordWrappedLocal =
           await key.toPaserkPassword(password: password);
-      output['paserkLocalPw'] = paserkLocalPw;
+      output['passwordWrappedLocalKey'] = passwordWrappedLocal;
       _applyPasswordMetadata(
         output,
         _parsePaserkPasswordMetadata(
-          paserkLocalPw,
+          passwordWrappedLocal,
           ['symmetric', 'info'],
         ),
+        prefix: 'passwordWrap',
       );
     } else if (paserk.startsWith('k4.local-pw')) {
-      output['paserkLocalPw'] = paserk;
+      output['passwordWrappedLocalKey'] = paserk;
       _applyPasswordMetadata(
         output,
         _parsePaserkPasswordMetadata(paserk, ['symmetric', 'info']),
+        prefix: 'passwordWrap',
       );
     }
 
     if (wrappingKey != null) {
-      output['paserkLocalWrap'] = key.toPaserkWrap(wrappingKey: wrappingKey);
+      output['wrappedLocalKeyPaserk'] =
+          key.toPaserkWrap(wrappingKey: wrappingKey);
     } else if (paserk.startsWith('k4.local-wrap')) {
-      output['paserkLocalWrap'] = paserk;
+      output['wrappedLocalKeyPaserk'] = paserk;
     }
 
     if (publicKey != null) {
-      output['paserkSeal'] = await key.toPaserkSeal(publicKey: publicKey);
+      output['sealedLocalKeyPaserk'] =
+          await key.toPaserkSeal(publicKey: publicKey);
     } else if (paserk.startsWith('k4.seal')) {
-      output['paserkSeal'] = paserk;
+      output['sealedLocalKeyPaserk'] = paserk;
     }
 
     await _printJson(output, pretty: pretty, outputPath: outputPath);
@@ -774,28 +784,32 @@ Future<void> _handleSymmetricDerive(
   );
 
   try {
+    final String passwordWrappedLocal =
+        await key.toPaserkPassword(password: password);
+
     final Map<String, Object?> output = {
       'type': 'xchacha20-key',
-      'salt': salt.asString(),
-      'memoryCost': memoryCost,
-      'timeCost': timeCost,
-      'parallelism': parallelism,
-      'paserkLocal': key.toPaserk(),
-      'localId': key.toPaserkIdentifier(),
-      'paserkLocalPw': await key.toPaserkPassword(password: password),
+      'deriveSalt': salt.asString(),
+      'deriveMemoryCost': memoryCost,
+      'deriveTimeCost': timeCost,
+      'deriveParallelism': parallelism,
+      'localKeyPaserk': key.toPaserk(),
+      'localKeyId': key.toPaserkIdentifier(),
+      'passwordWrappedLocalKey': passwordWrappedLocal,
     };
 
     _applyPasswordMetadata(
       output,
       _parsePaserkPasswordMetadata(
-        output['paserkLocalPw']! as String,
+        passwordWrappedLocal,
         ['symmetric', 'derive'],
       ),
-      preferTopLevelSalt: false,
+      prefix: 'passwordWrap',
     );
 
     if (sealKey != null) {
-      output['paserkSeal'] = await key.toPaserkSeal(publicKey: sealKey);
+      output['sealedLocalKeyPaserk'] =
+          await key.toPaserkSeal(publicKey: sealKey);
     }
 
     await _printJson(output, pretty: pretty, outputPath: outputPath);
@@ -1014,21 +1028,16 @@ String _detectKeyPairFormat(String paserk) {
 void _applyPasswordMetadata(
   Map<String, Object?> output,
   _PaserkPasswordMetadata? metadata, {
-  bool preferTopLevelSalt = true,
+  required String prefix,
 }) {
   if (metadata == null) {
     return;
   }
 
-  output['passwordSalt'] = metadata.salt;
-  output['passwordMemoryCost'] = metadata.memoryCost;
-  output['passwordTimeCost'] = metadata.timeCost;
-  output['passwordParallelism'] = metadata.parallelism;
-  if (preferTopLevelSalt) {
-    output['salt'] = metadata.salt;
-  } else {
-    output.putIfAbsent('salt', () => metadata.salt);
-  }
+  output['${prefix}Salt'] = metadata.salt;
+  output['${prefix}MemoryCost'] = metadata.memoryCost;
+  output['${prefix}TimeCost'] = metadata.timeCost;
+  output['${prefix}Parallelism'] = metadata.parallelism;
 }
 
 _PaserkPasswordMetadata? _parsePaserkPasswordMetadata(

--- a/bin/licensify.dart
+++ b/bin/licensify.dart
@@ -10,7 +10,15 @@ import 'package:args/args.dart';
 import 'package:licensify/licensify.dart';
 import 'package:paseto_dart/paseto_dart.dart';
 
-final ArgParser _keypairGenerateParser = ArgParser()
+ArgParser _parserWithHelp() => ArgParser()
+  ..addFlag(
+    'help',
+    abbr: 'h',
+    negatable: false,
+    help: 'Show usage information.',
+  );
+
+final ArgParser _keypairGenerateParser = _parserWithHelp()
   ..addOption(
     'password',
     help:
@@ -21,7 +29,7 @@ final ArgParser _keypairGenerateParser = ArgParser()
     help: 'Additionally emit k4.secret-wrap.pie using the provided k4.local key.',
   );
 
-final ArgParser _keypairInfoParser = ArgParser()
+final ArgParser _keypairInfoParser = _parserWithHelp()
   ..addOption(
     'paserk',
     help: 'PASERK string to inspect (k4.secret*, k4.public).',
@@ -35,11 +43,11 @@ final ArgParser _keypairInfoParser = ArgParser()
     help: 'Wrapping key (k4.local) required to open k4.secret-wrap.pie inputs.',
   );
 
-final ArgParser _keypairParser = ArgParser()
+final ArgParser _keypairParser = _parserWithHelp()
   ..addCommand('generate', _keypairGenerateParser)
   ..addCommand('info', _keypairInfoParser);
 
-final ArgParser _symmetricGenerateParser = ArgParser()
+final ArgParser _symmetricGenerateParser = _parserWithHelp()
   ..addOption(
     'password',
     help:
@@ -54,7 +62,7 @@ final ArgParser _symmetricGenerateParser = ArgParser()
     help: 'Additionally emit k4.seal using the provided k4.public key.',
   );
 
-final ArgParser _symmetricInfoParser = ArgParser()
+final ArgParser _symmetricInfoParser = _parserWithHelp()
   ..addOption(
     'paserk',
     help:
@@ -82,7 +90,7 @@ final ArgParser _symmetricInfoParser = ArgParser()
         'Wrapping key (k4.local) for the key pair if --keypair is k4.secret-wrap.pie.',
   );
 
-final ArgParser _symmetricDeriveParser = ArgParser()
+final ArgParser _symmetricDeriveParser = _parserWithHelp()
   ..addOption(
     'password',
     help: 'Password to derive the symmetric key from.',
@@ -113,27 +121,22 @@ final ArgParser _symmetricDeriveParser = ArgParser()
     help: 'Additionally emit k4.seal using the provided k4.public key.',
   );
 
-final ArgParser _symmetricParser = ArgParser()
+final ArgParser _symmetricParser = _parserWithHelp()
   ..addCommand('generate', _symmetricGenerateParser)
   ..addCommand('info', _symmetricInfoParser)
   ..addCommand('derive', _symmetricDeriveParser);
 
-final ArgParser _saltGenerateParser = ArgParser()
+final ArgParser _saltGenerateParser = _parserWithHelp()
   ..addOption(
     'length',
     help:
         'Length of the generated salt in bytes (defaults to PASERK minimum).',
   );
 
-final ArgParser _saltParser = ArgParser()..addCommand('generate', _saltGenerateParser);
+final ArgParser _saltParser = _parserWithHelp()
+  ..addCommand('generate', _saltGenerateParser);
 
-final ArgParser _rootParser = ArgParser()
-  ..addFlag(
-    'help',
-    abbr: 'h',
-    negatable: false,
-    help: 'Show usage information.',
-  )
+final ArgParser _rootParser = _parserWithHelp()
   ..addFlag(
     'pretty',
     defaultsTo: true,
@@ -212,6 +215,11 @@ Future<void> _handleKeypair(
   _CliInput? fileInput,
   String? outputPath,
 ) async {
+  if (command['help'] == true) {
+    _printUsage(['keypair']);
+    return;
+  }
+
   final ArgResults? subcommand = command.command;
   if (subcommand == null) {
     throw _CliUsageException('Missing keypair subcommand.', ['keypair']);
@@ -238,6 +246,11 @@ Future<void> _handleSymmetric(
   _CliInput? fileInput,
   String? outputPath,
 ) async {
+  if (command['help'] == true) {
+    _printUsage(['symmetric']);
+    return;
+  }
+
   final ArgResults? subcommand = command.command;
   if (subcommand == null) {
     throw _CliUsageException('Missing symmetric subcommand.', ['symmetric']);
@@ -266,6 +279,11 @@ Future<void> _handleSalt(
   bool pretty,
   String? outputPath,
 ) async {
+  if (command['help'] == true) {
+    _printUsage(['salt']);
+    return;
+  }
+
   final ArgResults? subcommand = command.command;
   if (subcommand == null) {
     throw _CliUsageException('Missing salt subcommand.', ['salt']);
@@ -288,6 +306,11 @@ Future<void> _handleKeypairGenerate(
   bool pretty,
   String? outputPath,
 ) async {
+  if (args['help'] == true) {
+    _printUsage(['keypair', 'generate']);
+    return;
+  }
+
   final String? password = _trimmedValue(args['password']);
   final String? wrapPaserk = _trimmedValue(args['wrap']);
 
@@ -333,6 +356,11 @@ Future<void> _handleKeypairInfo(
   _CliInput? fileInput,
   String? outputPath,
 ) async {
+  if (args['help'] == true) {
+    _printUsage(['keypair', 'info']);
+    return;
+  }
+
   final String? paserkInput = _trimmedValue(args['paserk']) ??
       _paserkFromInput(fileInput, const [
         'paserkSecret',
@@ -438,6 +466,11 @@ Future<void> _handleSymmetricGenerate(
   bool pretty,
   String? outputPath,
 ) async {
+  if (args['help'] == true) {
+    _printUsage(['symmetric', 'generate']);
+    return;
+  }
+
   final String? password = _trimmedValue(args['password']);
   final String? wrapPaserk = _trimmedValue(args['wrap']);
   final String? sealWith = _trimmedValue(args['seal-with']);
@@ -488,6 +521,11 @@ Future<void> _handleSymmetricInfo(
   _CliInput? fileInput,
   String? outputPath,
 ) async {
+  if (args['help'] == true) {
+    _printUsage(['symmetric', 'info']);
+    return;
+  }
+
   final String? paserkInput = _trimmedValue(args['paserk']) ??
       _paserkFromInput(fileInput, const [
         'paserkLocal',
@@ -606,6 +644,11 @@ Future<void> _handleSymmetricDerive(
   bool pretty,
   String? outputPath,
 ) async {
+  if (args['help'] == true) {
+    _printUsage(['symmetric', 'derive']);
+    return;
+  }
+
   final String? password = _trimmedValue(args['password']);
   if (password == null || password.isEmpty) {
     throw _CliUsageException(
@@ -694,6 +737,11 @@ Future<void> _handleSaltGenerate(
   bool pretty,
   String? outputPath,
 ) async {
+  if (args['help'] == true) {
+    _printUsage(['salt', 'generate']);
+    return;
+  }
+
   final String? lengthRaw = _trimmedValue(args['length']);
   LicensifySalt salt;
 

--- a/bin/licensify.dart
+++ b/bin/licensify.dart
@@ -1,0 +1,845 @@
+// SPDX-FileCopyrightText: 2025 Karim "nogipx" Mamatkazin <nogipx@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:licensify/licensify.dart';
+import 'package:paseto_dart/paseto_dart.dart';
+
+final ArgParser _keypairGenerateParser = ArgParser()
+  ..addOption(
+    'password',
+    help:
+        'Additionally emit k4.secret-pw using the provided password (Argon2id defaults).',
+  )
+  ..addOption(
+    'wrap',
+    help: 'Additionally emit k4.secret-wrap.pie using the provided k4.local key.',
+  );
+
+final ArgParser _keypairInfoParser = ArgParser()
+  ..addOption(
+    'paserk',
+    help: 'PASERK string to inspect (k4.secret*, k4.public).',
+  )
+  ..addOption(
+    'password',
+    help: 'Password required to open k4.secret-pw inputs.',
+  )
+  ..addOption(
+    'wrap',
+    help: 'Wrapping key (k4.local) required to open k4.secret-wrap.pie inputs.',
+  );
+
+final ArgParser _keypairParser = ArgParser()
+  ..addCommand('generate', _keypairGenerateParser)
+  ..addCommand('info', _keypairInfoParser);
+
+final ArgParser _symmetricGenerateParser = ArgParser()
+  ..addOption(
+    'password',
+    help:
+        'Additionally emit k4.local-pw using the provided password (Argon2id defaults).',
+  )
+  ..addOption(
+    'wrap',
+    help: 'Additionally emit k4.local-wrap.pie using the provided k4.local key.',
+  )
+  ..addOption(
+    'seal-with',
+    help: 'Additionally emit k4.seal using the provided k4.public key.',
+  );
+
+final ArgParser _symmetricInfoParser = ArgParser()
+  ..addOption(
+    'paserk',
+    help:
+        'PASERK string to inspect (k4.local*, k4.seal). Use --keypair when unsealing.',
+  )
+  ..addOption(
+    'password',
+    help: 'Password required to open k4.local-pw inputs.',
+  )
+  ..addOption(
+    'wrap',
+    help: 'Wrapping key (k4.local) required to open k4.local-wrap.pie inputs.',
+  )
+  ..addOption(
+    'keypair',
+    help: 'PASERK key pair (k4.secret*) required to unseal k4.seal inputs.',
+  )
+  ..addOption(
+    'keypair-password',
+    help: 'Password for the key pair if --keypair is k4.secret-pw.',
+  )
+  ..addOption(
+    'keypair-wrap',
+    help:
+        'Wrapping key (k4.local) for the key pair if --keypair is k4.secret-wrap.pie.',
+  );
+
+final ArgParser _symmetricDeriveParser = ArgParser()
+  ..addOption(
+    'password',
+    help: 'Password to derive the symmetric key from.',
+  )
+  ..addOption(
+    'salt',
+    help:
+        'Base64url salt for Argon2id (see "licensify salt generate").',
+  )
+  ..addOption(
+    'memory-cost',
+    defaultsTo: K4LocalPw.defaultMemoryCost.toString(),
+    help:
+        'Argon2 memory cost in kibibytes (must be a positive multiple of 1024).',
+  )
+  ..addOption(
+    'time-cost',
+    defaultsTo: K4LocalPw.defaultTimeCost.toString(),
+    help: 'Argon2 iterations (positive integer).',
+  )
+  ..addOption(
+    'parallelism',
+    defaultsTo: K4LocalPw.defaultParallelism.toString(),
+    help: 'Argon2 lanes/parallelism (positive integer).',
+  )
+  ..addOption(
+    'seal-with',
+    help: 'Additionally emit k4.seal using the provided k4.public key.',
+  );
+
+final ArgParser _symmetricParser = ArgParser()
+  ..addCommand('generate', _symmetricGenerateParser)
+  ..addCommand('info', _symmetricInfoParser)
+  ..addCommand('derive', _symmetricDeriveParser);
+
+final ArgParser _saltGenerateParser = ArgParser()
+  ..addOption(
+    'length',
+    help:
+        'Length of the generated salt in bytes (defaults to PASERK minimum).',
+  );
+
+final ArgParser _saltParser = ArgParser()..addCommand('generate', _saltGenerateParser);
+
+final ArgParser _rootParser = ArgParser()
+  ..addFlag(
+    'help',
+    abbr: 'h',
+    negatable: false,
+    help: 'Show usage information.',
+  )
+  ..addFlag(
+    'pretty',
+    defaultsTo: true,
+    help: 'Pretty-print JSON output (disable with --no-pretty).',
+  )
+  ..addCommand('keypair', _keypairParser)
+  ..addCommand('symmetric', _symmetricParser)
+  ..addCommand('salt', _saltParser);
+
+Future<void> main(List<String> arguments) async {
+  ArgResults rootResults;
+  try {
+    rootResults = _rootParser.parse(arguments);
+  } on FormatException catch (e) {
+    _printUsage([], error: e.message);
+    exitCode = 64;
+    return;
+  }
+
+  if (rootResults['help'] as bool) {
+    _printUsage([]);
+    return;
+  }
+
+  final bool pretty = rootResults['pretty'] as bool;
+  final ArgResults? command = rootResults.command;
+  if (command == null) {
+    _printUsage([], error: 'Missing command.');
+    exitCode = 64;
+    return;
+  }
+
+  try {
+    switch (command.name) {
+      case 'keypair':
+        await _handleKeypair(command, pretty);
+        break;
+      case 'symmetric':
+        await _handleSymmetric(command, pretty);
+        break;
+      case 'salt':
+        await _handleSalt(command, pretty);
+        break;
+      default:
+        throw _CliUsageException('Unknown command "${command.name}".', []);
+    }
+  } on _CliUsageException catch (e) {
+    _printUsage(e.commandPath, error: e.message);
+    exitCode = 64;
+  } catch (e, stackTrace) {
+    stderr.writeln('Unexpected error: $e');
+    stderr.writeln(stackTrace);
+    exitCode = 1;
+  }
+}
+
+Future<void> _handleKeypair(ArgResults command, bool pretty) async {
+  final ArgResults? subcommand = command.command;
+  if (subcommand == null) {
+    throw _CliUsageException('Missing keypair subcommand.', ['keypair']);
+  }
+
+  switch (subcommand.name) {
+    case 'generate':
+      await _handleKeypairGenerate(subcommand, pretty);
+      break;
+    case 'info':
+      await _handleKeypairInfo(subcommand, pretty);
+      break;
+    default:
+      throw _CliUsageException(
+        'Unknown keypair subcommand "${subcommand.name}".',
+        ['keypair'],
+      );
+  }
+}
+
+Future<void> _handleSymmetric(ArgResults command, bool pretty) async {
+  final ArgResults? subcommand = command.command;
+  if (subcommand == null) {
+    throw _CliUsageException('Missing symmetric subcommand.', ['symmetric']);
+  }
+
+  switch (subcommand.name) {
+    case 'generate':
+      await _handleSymmetricGenerate(subcommand, pretty);
+      break;
+    case 'info':
+      await _handleSymmetricInfo(subcommand, pretty);
+      break;
+    case 'derive':
+      await _handleSymmetricDerive(subcommand, pretty);
+      break;
+    default:
+      throw _CliUsageException(
+        'Unknown symmetric subcommand "${subcommand.name}".',
+        ['symmetric'],
+      );
+  }
+}
+
+Future<void> _handleSalt(ArgResults command, bool pretty) async {
+  final ArgResults? subcommand = command.command;
+  if (subcommand == null) {
+    throw _CliUsageException('Missing salt subcommand.', ['salt']);
+  }
+
+  switch (subcommand.name) {
+    case 'generate':
+      await _handleSaltGenerate(subcommand, pretty);
+      break;
+    default:
+      throw _CliUsageException(
+        'Unknown salt subcommand "${subcommand.name}".',
+        ['salt'],
+      );
+  }
+}
+
+Future<void> _handleKeypairGenerate(ArgResults args, bool pretty) async {
+  final String? password = _trimmedValue(args['password']);
+  final String? wrapPaserk = _trimmedValue(args['wrap']);
+
+  LicensifySymmetricKey? wrappingKey;
+  if (wrapPaserk != null) {
+    wrappingKey = _parseSymmetricKey(wrapPaserk, ['keypair', 'generate']);
+  }
+
+  final LicensifyKeyPair pair = await LicensifyKey.generatePublicKeyPair();
+
+  try {
+    final Map<String, Object?> output = {
+      'type': 'ed25519-keypair',
+      'publicKeyPaserk': pair.publicKey.toPaserk(),
+      'publicKeyId': pair.publicKey.toPaserkIdentifier(),
+      'paserkSecret': pair.toPaserkSecret(),
+      'secretId': pair.toPaserkSecretIdentifier(),
+    };
+
+    if (password != null && password.isNotEmpty) {
+      output['paserkSecretPw'] = await pair.toPaserkSecretPassword(
+        password: password,
+      );
+    }
+
+    if (wrappingKey != null) {
+      output['paserkSecretWrap'] = pair.toPaserkSecretWrap(
+        wrappingKey: wrappingKey,
+      );
+    }
+
+    _printJson(output, pretty: pretty);
+  } finally {
+    pair.privateKey.dispose();
+    pair.publicKey.dispose();
+    wrappingKey?.dispose();
+  }
+}
+
+Future<void> _handleKeypairInfo(ArgResults args, bool pretty) async {
+  final String? paserkInput = _trimmedValue(args['paserk']);
+  if (paserkInput == null || paserkInput.isEmpty) {
+    throw _CliUsageException('Provide --paserk with a PASERK string.', ['keypair', 'info']);
+  }
+
+  final String paserk = paserkInput;
+  final String? password = _trimmedValue(args['password']);
+  final String? wrapPaserk = _trimmedValue(args['wrap']);
+
+  if (paserk.startsWith('k4.public')) {
+    final LicensifyPublicKey publicKey = _parsePublicKey(paserk, ['keypair', 'info']);
+    try {
+      final Map<String, Object?> output = {
+        'type': 'ed25519-public-key',
+        'sourceFormat': 'k4.public',
+        'publicKeyPaserk': publicKey.toPaserk(),
+        'publicKeyId': publicKey.toPaserkIdentifier(),
+      };
+      _printJson(output, pretty: pretty);
+    } finally {
+      publicKey.dispose();
+    }
+    return;
+  }
+
+  LicensifyKeyPair? pair;
+  LicensifySymmetricKey? wrappingKey;
+
+  try {
+    if (paserk.startsWith('k4.secret-pw')) {
+      if (password == null || password.isEmpty) {
+        throw _CliUsageException(
+          'Provide --password to open k4.secret-pw inputs.',
+          ['keypair', 'info'],
+        );
+      }
+      pair = await LicensifyKeyPair.fromPaserkSecretPassword(
+        paserk: paserk,
+        password: password,
+      );
+    } else if (paserk.startsWith('k4.secret-wrap')) {
+      if (wrapPaserk == null || wrapPaserk.isEmpty) {
+        throw _CliUsageException(
+          'Provide --wrap with the wrapping k4.local key to open k4.secret-wrap.pie inputs.',
+          ['keypair', 'info'],
+        );
+      }
+      wrappingKey = _parseSymmetricKey(wrapPaserk, ['keypair', 'info']);
+      pair = LicensifyKeyPair.fromPaserkSecretWrap(
+        paserk: paserk,
+        wrappingKey: wrappingKey,
+      );
+    } else if (paserk.startsWith('k4.secret')) {
+      pair = LicensifyKeyPair.fromPaserkSecret(paserk: paserk);
+    } else {
+      throw _CliUsageException(
+        'Unsupported PASERK format for key pairs: $paserk',
+        ['keypair', 'info'],
+      );
+    }
+
+    final Map<String, Object?> output = {
+      'type': 'ed25519-keypair',
+      'sourceFormat': _detectKeyPairFormat(paserk),
+      'publicKeyPaserk': pair.publicKey.toPaserk(),
+      'publicKeyId': pair.publicKey.toPaserkIdentifier(),
+      'paserkSecret': pair.toPaserkSecret(),
+      'secretId': pair.toPaserkSecretIdentifier(),
+    };
+
+    if (password != null && password.isNotEmpty) {
+      output['paserkSecretPw'] = await pair.toPaserkSecretPassword(
+        password: password,
+      );
+    } else if (paserk.startsWith('k4.secret-pw')) {
+      output['paserkSecretPw'] = paserk;
+    }
+
+    if (wrappingKey != null) {
+      output['paserkSecretWrap'] = pair.toPaserkSecretWrap(
+        wrappingKey: wrappingKey,
+      );
+    } else if (paserk.startsWith('k4.secret-wrap')) {
+      output['paserkSecretWrap'] = paserk;
+    }
+
+    _printJson(output, pretty: pretty);
+  } finally {
+    pair?.privateKey.dispose();
+    pair?.publicKey.dispose();
+    wrappingKey?.dispose();
+  }
+}
+
+Future<void> _handleSymmetricGenerate(ArgResults args, bool pretty) async {
+  final String? password = _trimmedValue(args['password']);
+  final String? wrapPaserk = _trimmedValue(args['wrap']);
+  final String? sealWith = _trimmedValue(args['seal-with']);
+
+  LicensifySymmetricKey? wrappingKey;
+  LicensifyPublicKey? sealingKey;
+
+  if (wrapPaserk != null) {
+    wrappingKey = _parseSymmetricKey(wrapPaserk, ['symmetric', 'generate']);
+  }
+
+  if (sealWith != null) {
+    sealingKey = _parsePublicKey(sealWith, ['symmetric', 'generate']);
+  }
+
+  final LicensifySymmetricKey key = LicensifyKey.generateLocalKey();
+
+  try {
+    final Map<String, Object?> output = {
+      'type': 'xchacha20-key',
+      'paserkLocal': key.toPaserk(),
+      'localId': key.toPaserkIdentifier(),
+    };
+
+    if (password != null && password.isNotEmpty) {
+      output['paserkLocalPw'] = await key.toPaserkPassword(password: password);
+    }
+
+    if (wrappingKey != null) {
+      output['paserkLocalWrap'] = key.toPaserkWrap(wrappingKey: wrappingKey);
+    }
+
+    if (sealingKey != null) {
+      output['paserkSeal'] = await key.toPaserkSeal(publicKey: sealingKey);
+    }
+
+    _printJson(output, pretty: pretty);
+  } finally {
+    key.dispose();
+    wrappingKey?.dispose();
+    sealingKey?.dispose();
+  }
+}
+
+Future<void> _handleSymmetricInfo(ArgResults args, bool pretty) async {
+  final String? paserkInput = _trimmedValue(args['paserk']);
+  if (paserkInput == null || paserkInput.isEmpty) {
+    throw _CliUsageException('Provide --paserk with a PASERK string.', ['symmetric', 'info']);
+  }
+
+  final String paserk = paserkInput;
+  final String? password = _trimmedValue(args['password']);
+  final String? wrapPaserk = _trimmedValue(args['wrap']);
+
+  LicensifySymmetricKey? key;
+  LicensifySymmetricKey? wrappingKey;
+  LicensifyKeyPair? keyPair;
+  LicensifyPublicKey? publicKey;
+
+  try {
+    if (paserk.startsWith('k4.local-pw')) {
+      if (password == null || password.isEmpty) {
+        throw _CliUsageException(
+          'Provide --password to open k4.local-pw inputs.',
+          ['symmetric', 'info'],
+        );
+      }
+      key = await LicensifySymmetricKey.fromPaserkPassword(
+        paserk: paserk,
+        password: password,
+      );
+    } else if (paserk.startsWith('k4.local-wrap')) {
+      if (wrapPaserk == null || wrapPaserk.isEmpty) {
+        throw _CliUsageException(
+          'Provide --wrap with the wrapping k4.local key to open k4.local-wrap.pie inputs.',
+          ['symmetric', 'info'],
+        );
+      }
+      wrappingKey = _parseSymmetricKey(wrapPaserk, ['symmetric', 'info']);
+      key = LicensifySymmetricKey.fromPaserkWrap(
+        paserk: paserk,
+        wrappingKey: wrappingKey,
+      );
+    } else if (paserk.startsWith('k4.seal')) {
+      final String? keyPairPaserk = _trimmedValue(args['keypair']);
+      if (keyPairPaserk == null || keyPairPaserk.isEmpty) {
+        throw _CliUsageException(
+          'Provide --keypair with a k4.secret* value to unseal k4.seal inputs.',
+          ['symmetric', 'info'],
+        );
+      }
+      final String? keyPairPassword = _trimmedValue(args['keypair-password']);
+      final String? keyPairWrap = _trimmedValue(args['keypair-wrap']);
+      keyPair = await _loadKeyPair(
+        paserk: keyPairPaserk,
+        password: keyPairPassword,
+        wrappingKeyPaserk: keyPairWrap,
+        commandPath: ['symmetric', 'info'],
+      );
+      key = await LicensifySymmetricKey.fromPaserkSeal(
+        paserk: paserk,
+        keyPair: keyPair,
+      );
+      publicKey = keyPair.publicKey;
+    } else if (paserk.startsWith('k4.local')) {
+      key = LicensifySymmetricKey.fromPaserk(paserk: paserk);
+    } else {
+      throw _CliUsageException(
+        'Unsupported PASERK format for symmetric keys: $paserk',
+        ['symmetric', 'info'],
+      );
+    }
+
+    final Map<String, Object?> output = {
+      'type': 'xchacha20-key',
+      'sourceFormat': _detectSymmetricFormat(paserk),
+      'paserkLocal': key.toPaserk(),
+      'localId': key.toPaserkIdentifier(),
+    };
+
+    if (password != null && password.isNotEmpty) {
+      output['paserkLocalPw'] = await key.toPaserkPassword(password: password);
+    } else if (paserk.startsWith('k4.local-pw')) {
+      output['paserkLocalPw'] = paserk;
+    }
+
+    if (wrappingKey != null) {
+      output['paserkLocalWrap'] = key.toPaserkWrap(wrappingKey: wrappingKey);
+    } else if (paserk.startsWith('k4.local-wrap')) {
+      output['paserkLocalWrap'] = paserk;
+    }
+
+    if (publicKey != null) {
+      output['paserkSeal'] = await key.toPaserkSeal(publicKey: publicKey);
+    } else if (paserk.startsWith('k4.seal')) {
+      output['paserkSeal'] = paserk;
+    }
+
+    _printJson(output, pretty: pretty);
+  } finally {
+    key?.dispose();
+    wrappingKey?.dispose();
+    if (keyPair != null) {
+      keyPair.privateKey.dispose();
+      if (!keyPair.publicKey.isDisposed) {
+        keyPair.publicKey.dispose();
+      }
+    }
+    publicKey?.dispose();
+  }
+}
+
+Future<void> _handleSymmetricDerive(ArgResults args, bool pretty) async {
+  final String? password = _trimmedValue(args['password']);
+  if (password == null || password.isEmpty) {
+    throw _CliUsageException(
+      'Provide --password with the secret used for key derivation.',
+      ['symmetric', 'derive'],
+    );
+  }
+
+  final String? saltInput = _trimmedValue(args['salt']);
+  if (saltInput == null || saltInput.isEmpty) {
+    throw _CliUsageException(
+      'Provide --salt with a base64url encoded salt.',
+      ['symmetric', 'derive'],
+    );
+  }
+
+  final int memoryCost = _parsePositiveInt(
+    args['memory-cost'],
+    'memory-cost',
+    ['symmetric', 'derive'],
+  );
+  final int timeCost = _parsePositiveInt(
+    args['time-cost'],
+    'time-cost',
+    ['symmetric', 'derive'],
+  );
+  final int parallelism = _parsePositiveInt(
+    args['parallelism'],
+    'parallelism',
+    ['symmetric', 'derive'],
+  );
+
+  if (memoryCost % 1024 != 0) {
+    throw _CliUsageException(
+      '--memory-cost must be a positive multiple of 1024.',
+      ['symmetric', 'derive'],
+    );
+  }
+
+  final LicensifySalt salt;
+  try {
+    salt = LicensifySalt.fromString(value: saltInput);
+  } on FormatException catch (e) {
+    throw _CliUsageException(e.message, ['symmetric', 'derive']);
+  }
+
+  LicensifyPublicKey? sealKey;
+  final String? sealWith = _trimmedValue(args['seal-with']);
+  if (sealWith != null) {
+    sealKey = _parsePublicKey(sealWith, ['symmetric', 'derive']);
+  }
+
+  final LicensifySymmetricKey key = await LicensifySymmetricKey.fromPassword(
+    password: password,
+    salt: salt,
+    memoryCost: memoryCost,
+    timeCost: timeCost,
+    parallelism: parallelism,
+  );
+
+  try {
+    final Map<String, Object?> output = {
+      'type': 'xchacha20-key',
+      'salt': salt.asString(),
+      'memoryCost': memoryCost,
+      'timeCost': timeCost,
+      'parallelism': parallelism,
+      'paserkLocal': key.toPaserk(),
+      'localId': key.toPaserkIdentifier(),
+      'paserkLocalPw': await key.toPaserkPassword(password: password),
+    };
+
+    if (sealKey != null) {
+      output['paserkSeal'] = await key.toPaserkSeal(publicKey: sealKey);
+    }
+
+    _printJson(output, pretty: pretty);
+  } finally {
+    key.dispose();
+    sealKey?.dispose();
+  }
+}
+
+Future<void> _handleSaltGenerate(ArgResults args, bool pretty) async {
+  final String? lengthRaw = _trimmedValue(args['length']);
+  LicensifySalt salt;
+
+  if (lengthRaw == null || lengthRaw.isEmpty) {
+    salt = LicensifySymmetricKey.generatePasswordSalt();
+  } else {
+    final int length = _parsePositiveInt(lengthRaw, 'length', ['salt', 'generate']);
+    salt = LicensifySalt.random(length: length);
+  }
+
+  final Map<String, Object?> output = {
+    'type': 'argon2-salt',
+    'salt': salt.asString(),
+    'length': salt.length,
+  };
+  _printJson(output, pretty: pretty);
+}
+
+LicensifySymmetricKey _parseSymmetricKey(String paserk, List<String> commandPath) {
+  try {
+    return LicensifySymmetricKey.fromPaserk(paserk: paserk);
+  } catch (e) {
+    throw _CliUsageException('Failed to parse k4.local key: $e', commandPath);
+  }
+}
+
+LicensifyPublicKey _parsePublicKey(String paserk, List<String> commandPath) {
+  try {
+    return LicensifyPublicKey.fromPaserk(paserk: paserk);
+  } catch (e) {
+    throw _CliUsageException('Failed to parse k4.public key: $e', commandPath);
+  }
+}
+
+Future<LicensifyKeyPair> _loadKeyPair({
+  required String paserk,
+  required List<String> commandPath,
+  String? password,
+  String? wrappingKeyPaserk,
+}) async {
+  if (paserk.startsWith('k4.secret-pw')) {
+    if (password == null || password.isEmpty) {
+      throw _CliUsageException(
+        'Provide --keypair-password to open the supplied key pair.',
+        commandPath,
+      );
+    }
+    return LicensifyKeyPair.fromPaserkSecretPassword(
+      paserk: paserk,
+      password: password,
+    );
+  }
+
+  if (paserk.startsWith('k4.secret-wrap')) {
+    if (wrappingKeyPaserk == null || wrappingKeyPaserk.isEmpty) {
+      throw _CliUsageException(
+        'Provide --keypair-wrap with the wrapping k4.local key.',
+        commandPath,
+      );
+    }
+    final LicensifySymmetricKey wrappingKey =
+        _parseSymmetricKey(wrappingKeyPaserk, commandPath);
+    try {
+      return LicensifyKeyPair.fromPaserkSecretWrap(
+        paserk: paserk,
+        wrappingKey: wrappingKey,
+      );
+    } finally {
+      wrappingKey.dispose();
+    }
+  }
+
+  if (paserk.startsWith('k4.secret')) {
+    return LicensifyKeyPair.fromPaserkSecret(paserk: paserk);
+  }
+
+  throw _CliUsageException(
+    'Unsupported PASERK format for key pair: $paserk',
+    commandPath,
+  );
+}
+
+int _parsePositiveInt(Object? value, String name, List<String> commandPath) {
+  final String? raw = _trimmedValue(value);
+  if (raw == null || raw.isEmpty) {
+    throw _CliUsageException('Provide --$name with a positive integer.', commandPath);
+  }
+
+  final int? parsed = int.tryParse(raw);
+  if (parsed == null || parsed <= 0) {
+    throw _CliUsageException('Provide --$name with a positive integer.', commandPath);
+  }
+  return parsed;
+}
+
+String? _trimmedValue(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  return value.toString().trim();
+}
+
+String _detectKeyPairFormat(String paserk) {
+  if (paserk.startsWith('k4.secret-pw')) {
+    return 'k4.secret-pw';
+  }
+  if (paserk.startsWith('k4.secret-wrap')) {
+    return 'k4.secret-wrap.pie';
+  }
+  if (paserk.startsWith('k4.secret')) {
+    return 'k4.secret';
+  }
+  if (paserk.startsWith('k4.public')) {
+    return 'k4.public';
+  }
+  return 'unknown';
+}
+
+String _detectSymmetricFormat(String paserk) {
+  if (paserk.startsWith('k4.local-pw')) {
+    return 'k4.local-pw';
+  }
+  if (paserk.startsWith('k4.local-wrap')) {
+    return 'k4.local-wrap.pie';
+  }
+  if (paserk.startsWith('k4.seal')) {
+    return 'k4.seal';
+  }
+  if (paserk.startsWith('k4.local')) {
+    return 'k4.local';
+  }
+  return 'unknown';
+}
+
+void _printJson(Map<String, Object?> data, {required bool pretty}) {
+  final JsonEncoder encoder = pretty
+      ? const JsonEncoder.withIndent('  ')
+      : const JsonEncoder();
+  stdout.writeln(encoder.convert(data));
+}
+
+void _printUsage(List<String> commandPath, {String? error}) {
+  if (error != null) {
+    stderr.writeln('Error: $error');
+    stderr.writeln('');
+  }
+
+  if (commandPath.isEmpty) {
+    stderr.writeln('Usage: licensify <command> [arguments]');
+    stderr.writeln('');
+    stderr.writeln(_rootParser.usage);
+    stderr.writeln('');
+    stderr.writeln('Commands:');
+    stderr.writeln('  keypair     Manage Ed25519 signing key material');
+    stderr.writeln('  symmetric   Manage XChaCha20 encryption keys');
+    stderr.writeln('  salt        Generate Argon2id salts');
+    return;
+  }
+
+  final String command = commandPath.first;
+  switch (command) {
+    case 'keypair':
+      stderr.writeln('Usage: licensify keypair <subcommand> [arguments]');
+      stderr.writeln('');
+      stderr.writeln(_keypairParser.usage);
+      if (commandPath.length > 1) {
+        final String sub = commandPath[1];
+        final ArgParser? subParser = _keypairParser.commands[sub];
+        if (subParser != null) {
+          stderr.writeln('');
+          stderr.writeln(subParser.usage);
+        }
+      }
+      return;
+    case 'symmetric':
+      stderr.writeln('Usage: licensify symmetric <subcommand> [arguments]');
+      stderr.writeln('');
+      stderr.writeln(_symmetricParser.usage);
+      if (commandPath.length > 1) {
+        final String sub = commandPath[1];
+        final ArgParser? subParser = _symmetricParser.commands[sub];
+        if (subParser != null) {
+          stderr.writeln('');
+          stderr.writeln(subParser.usage);
+        }
+      }
+      return;
+    case 'salt':
+      stderr.writeln('Usage: licensify salt <subcommand> [arguments]');
+      stderr.writeln('');
+      stderr.writeln(_saltParser.usage);
+      if (commandPath.length > 1) {
+        final String sub = commandPath[1];
+        final ArgParser? subParser = _saltParser.commands[sub];
+        if (subParser != null) {
+          stderr.writeln('');
+          stderr.writeln(subParser.usage);
+        }
+      }
+      return;
+    default:
+      stderr.writeln('Usage: licensify <command> [arguments]');
+      stderr.writeln('');
+      stderr.writeln(_rootParser.usage);
+      return;
+  }
+}
+
+class _CliUsageException implements Exception {
+  _CliUsageException(this.message, this.commandPath);
+
+  final String message;
+  final List<String> commandPath;
+
+  @override
+  String toString() => message;
+}

--- a/lib/src/crypto/keys/licensify_symmetric_key.dart
+++ b/lib/src/crypto/keys/licensify_symmetric_key.dart
@@ -89,7 +89,11 @@ final class LicensifySymmetricKey extends LicensifyKey {
     }
 
     final algorithm = Argon2id(
-      memory: memoryCost,
+      // Argon2id expects the memory parameter in kibibytes, while PASERK
+      // records it in raw bytes. Convert to maintain compatibility with
+      // `K4LocalPw.wrap`/`unwrap` so derived keys match wrapped outputs and
+      // avoid oversized allocations.
+      memory: memoryCost ~/ 1024,
       iterations: timeCost,
       parallelism: parallelism,
       hashLength: K4LocalKey.keyLength,

--- a/lib/src/crypto/keys/licensify_symmetric_key.dart
+++ b/lib/src/crypto/keys/licensify_symmetric_key.dart
@@ -72,6 +72,7 @@ final class LicensifySymmetricKey extends LicensifyKey {
   static Future<LicensifySymmetricKey> fromPassword({
     required String password,
     required LicensifySalt salt,
+    /// Memory cost expressed in bytes to mirror the PASERK `m` parameter.
     int memoryCost = K4LocalPw.defaultMemoryCost,
     int timeCost = K4LocalPw.defaultTimeCost,
     int parallelism = K4LocalPw.defaultParallelism,
@@ -88,7 +89,7 @@ final class LicensifySymmetricKey extends LicensifyKey {
     }
 
     final algorithm = Argon2id(
-      memory: memoryCost ~/ 1024,
+      memory: memoryCost,
       iterations: timeCost,
       parallelism: parallelism,
       hashLength: K4LocalKey.keyLength,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: licensify
 description: A modern Dart library for secure license generation and validation using PASETO v4.
-version: 4.0.0
+version: 4.1.0
 homepage: https://github.com/nogipx/licensify
 repository: https://github.com/nogipx/licensify
 issue_tracker: https://github.com/nogipx/licensify/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,9 +21,12 @@ dev_dependencies:
   test: ^1.21.0
   lints: ^4.0.0
 
+executables:
+  licensify: licensify
+
 topics:
   - license
-  - digital-signature 
-  - cryptography 
+  - digital-signature
+  - cryptography
   - software-licensing 
   - paseto


### PR DESCRIPTION
## Summary
- add a `licensify` command-line tool for generating, inspecting, and converting signing and symmetric keys, including PASERK helpers and Argon2 salt utilities
- document the CLI workflow in the README and register the executable for `dart pub global activate`
- record the new CLI in the changelog

## Testing
- not run (Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebb402d8e88333871f54303ba7a6ae