### PR TITLE
Add Paseto asymmetric encryption helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable changes to this project will be documented in this file.
   `Licensify.decryptDataForKeyPair` to wrap encrypted payloads with PASERK
   `k4.seal`, enabling delivery of secrets to recipients using only their public
   keys.
-- **Payload container**: Introduced `LicensifyAsymmetricEncryptedPayload` for
-  serialising sealed payloads and simplifying transports.
+- **Sealed-key footer**: Store the PASERK `k4.seal` inside the token footer so
+  asymmetric workflows can ship a single PASETO string without extra wrappers.
 
 ### 📚 Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.3.0] - 2025-10-18
+
+### ✨ New Features
+
+- **Asymmetric data encryption**: Added `Licensify.encryptDataForPublicKey` and
+  `Licensify.decryptDataForKeyPair` to wrap encrypted payloads with PASERK
+  `k4.seal`, enabling delivery of secrets to recipients using only their public
+  keys.
+- **Payload container**: Introduced `LicensifyAsymmetricEncryptedPayload` for
+  serialising sealed payloads and simplifying transports.
+
+### 📚 Documentation
+
+- Expanded the README and examples with sealed-encryption workflows and updated
+  the API reference to cover the new helpers.
+
+### 🧪 Testing
+
+- Added unit coverage ensuring sealed payloads can be decrypted only with the
+  matching key pair.
+
 ## [4.2.0] - 2025-10-13
 
 - Add NanoID generator

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Future<Map<String, dynamic>> encryptForRecipient() async {
   final keyPair = await Licensify.generateSigningKeys();
 
   try {
-    final payload = await Licensify.encryptDataForPublicKey(
+    final token = await Licensify.encryptDataForPublicKey(
       data: const {
         'backup': 'delta',
         'issued_at': '2025-10-18T12:00:00Z',
@@ -261,7 +261,7 @@ Future<Map<String, dynamic>> encryptForRecipient() async {
     );
 
     final recovered = await Licensify.decryptDataForKeyPair(
-      payload: payload,
+      encryptedToken: token,
       keyPair: keyPair,
     );
 
@@ -272,6 +272,10 @@ Future<Map<String, dynamic>> encryptForRecipient() async {
   }
 }
 ```
+
+> `encryptDataForPublicKey` сохраняет одноразовый `k4.seal` в footer токена, так
+> что для доставки достаточно передать строку `v4.local.*`. При расшифровке
+> исходный footer возвращается в поле `_footer` полезной нагрузки.
 
 ## Key lifecycle requirements
 Every `LicensifyPrivateKey`, `LicensifyPublicKey`, and `LicensifySymmetricKey` holds sensitive material in memory. Keys **must** be disposed explicitly with `.dispose()` once an operation completes. Failing to dispose keys leaves confidential bytes resident in memory until garbage collection and violates the library's security model.
@@ -325,8 +329,8 @@ static Future<LicenseValidationResult> validateLicenseWithKeyBytes({...});
 // Data encryption
 static Future<String> encryptData({required Map<String, dynamic> data, required LicensifySymmetricKey encryptionKey});
 static Future<Map<String, dynamic>> decryptData({required String encryptedToken, required LicensifySymmetricKey encryptionKey});
-static Future<LicensifyAsymmetricEncryptedPayload> encryptDataForPublicKey({required Map<String, dynamic> data, required LicensifyPublicKey publicKey});
-static Future<Map<String, dynamic>> decryptDataForKeyPair({required LicensifyAsymmetricEncryptedPayload payload, required LicensifyKeyPair keyPair});
+static Future<String> encryptDataForPublicKey({required Map<String, dynamic> data, required LicensifyPublicKey publicKey});
+static Future<Map<String, dynamic>> decryptDataForKeyPair({required String encryptedToken, required LicensifyKeyPair keyPair});
 ```
 
 Refer to the inline API documentation for parameter details and advanced usage notes.

--- a/example/main.dart
+++ b/example/main.dart
@@ -207,19 +207,17 @@ Future<void> dataEncryptionExample() async {
   // 4. Шифрование на публичный ключ с использованием `k4.seal`
   final recipientKeys = await Licensify.generateSigningKeys();
   try {
-    final sealedPayload = await Licensify.encryptDataForPublicKey(
+    final asymmetricToken = await Licensify.encryptDataForPublicKey(
       data: sensitiveData,
       publicKey: recipientKeys.publicKey,
       footer: 'sealed_backup=v1',
     );
 
     print('✅ Данные зашифрованы на публичный ключ получателя');
-    print('   Sealed key: ${sealedPayload.sealedKey.substring(0, 40)}...');
-    print(
-        '   Token preview: ${sealedPayload.encryptedToken.substring(0, 40)}...');
+    print('   Token preview: ${asymmetricToken.substring(0, 50)}...');
 
     final recovered = await Licensify.decryptDataForKeyPair(
-      payload: sealedPayload,
+      encryptedToken: asymmetricToken,
       keyPair: recipientKeys,
     );
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -203,6 +203,33 @@ Future<void> dataEncryptionExample() async {
     // 🛡️ Важно! Очищаем ключ
     encryptionKey.dispose();
   }
+
+  // 4. Шифрование на публичный ключ с использованием `k4.seal`
+  final recipientKeys = await Licensify.generateSigningKeys();
+  try {
+    final sealedPayload = await Licensify.encryptDataForPublicKey(
+      data: sensitiveData,
+      publicKey: recipientKeys.publicKey,
+      footer: 'sealed_backup=v1',
+    );
+
+    print('✅ Данные зашифрованы на публичный ключ получателя');
+    print('   Sealed key: ${sealedPayload.sealedKey.substring(0, 40)}...');
+    print(
+        '   Token preview: ${sealedPayload.encryptedToken.substring(0, 40)}...');
+
+    final recovered = await Licensify.decryptDataForKeyPair(
+      payload: sealedPayload,
+      keyPair: recipientKeys,
+    );
+
+    print('✅ Расшифровка приватным ключом успешна');
+    print('   Footer: ${recovered['_footer']}');
+    print('   User ID: ${recovered['user_id']}');
+  } finally {
+    recipientKeys.privateKey.dispose();
+    recipientKeys.publicKey.dispose();
+  }
 }
 
 /// Продвинутые secure операции с автоматическим управлением ключами

--- a/lib/licensify.dart
+++ b/lib/licensify.dart
@@ -18,6 +18,7 @@ part 'src/crypto/keys/licensify_salt.dart';
 part 'src/crypto/keys/licensify_symmetric_key.dart';
 part 'src/crypto/license_generator.dart';
 part 'src/crypto/license_validator.dart';
+part 'src/crypto/licensify_asymmetric_crypto.dart';
 part 'src/crypto/licensify_symmetric_crypto.dart';
 part 'src/crypto/nanoid.dart';
 part 'src/crypto/paseto_v4.dart';

--- a/lib/src/crypto/licensify_asymmetric_crypto.dart
+++ b/lib/src/crypto/licensify_asymmetric_crypto.dart
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2025 Karim "nogipx" Mamatkazin <nogipx@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+part of 'package:licensify/licensify.dart';
+
+/// Encapsulates the result of encrypting data for a recipient's public key.
+///
+/// The encrypted payload combines a sealed symmetric key (`k4.seal`) with the
+/// actual PASETO `v4.local` token produced using that symmetric key. Consumers
+/// can persist the entire object as JSON and later restore it via
+/// [LicensifyAsymmetricEncryptedPayload.fromJson] before calling
+/// [Licensify.decryptDataForKeyPair].
+final class LicensifyAsymmetricEncryptedPayload {
+  /// The encrypted PASETO `v4.local` token that contains the ciphertext.
+  final String encryptedToken;
+
+  /// PASERK `k4.seal` string carrying the symmetric key encrypted for the
+  /// recipient's public key.
+  final String sealedKey;
+
+  /// Optional footer that was supplied during encryption. It remains stored in
+  /// plaintext inside the PASETO token but is surfaced here for convenience
+  /// when serialising the payload alongside metadata.
+  final String? footer;
+
+  const LicensifyAsymmetricEncryptedPayload({
+    required this.encryptedToken,
+    required this.sealedKey,
+    this.footer,
+  });
+
+  /// Serialises the payload into a JSON-friendly structure.
+  Map<String, dynamic> toJson() {
+    return {
+      'encryptedToken': encryptedToken,
+      'sealedKey': sealedKey,
+      if (footer != null) 'footer': footer,
+    };
+  }
+
+  /// Restores a payload from a JSON map.
+  factory LicensifyAsymmetricEncryptedPayload.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final encryptedToken = json['encryptedToken'];
+    final sealedKey = json['sealedKey'];
+    final footer = json['footer'];
+
+    if (encryptedToken is! String || encryptedToken.isEmpty) {
+      throw ArgumentError(
+        'encryptedToken must be a non-empty string in the JSON payload',
+      );
+    }
+    if (sealedKey is! String || sealedKey.isEmpty) {
+      throw ArgumentError(
+        'sealedKey must be a non-empty string in the JSON payload',
+      );
+    }
+    if (footer != null && footer is! String) {
+      throw ArgumentError('footer must be a string when provided');
+    }
+
+    return LicensifyAsymmetricEncryptedPayload(
+      encryptedToken: encryptedToken,
+      sealedKey: sealedKey,
+      footer: footer as String?,
+    );
+  }
+
+  @override
+  String toString() {
+    final previewToken =
+        encryptedToken.length > 16 ? '${encryptedToken.substring(0, 16)}…' : encryptedToken;
+    final previewSeal =
+        sealedKey.length > 16 ? '${sealedKey.substring(0, 16)}…' : sealedKey;
+    return 'LicensifyAsymmetricEncryptedPayload(token: $previewToken, sealedKey: $previewSeal)';
+  }
+}
+
+/// Handles asymmetric encryption flows built on top of PASERK `k4.seal`.
+abstract final class _LicensifyAsymmetricCrypto {
+  /// Encrypts [data] for the holder of [publicKey].
+  static Future<LicensifyAsymmetricEncryptedPayload> encrypt({
+    required Map<String, dynamic> data,
+    required LicensifyPublicKey publicKey,
+    String? footer,
+    String? implicitAssertion,
+  }) async {
+    final symmetricKey = LicensifyKey.generateLocalKey();
+    try {
+      final crypto = _LicensifySymmetricCrypto(symmetricKey: symmetricKey);
+      final token = await crypto.encrypt(
+        data,
+        footer: footer,
+        implicitAssertion: implicitAssertion,
+      );
+
+      final sealedKey = await symmetricKey.toPaserkSeal(publicKey: publicKey);
+      return LicensifyAsymmetricEncryptedPayload(
+        encryptedToken: token,
+        sealedKey: sealedKey,
+        footer: footer,
+      );
+    } catch (e) {
+      throw Exception('Failed to encrypt data for the provided public key: $e');
+    } finally {
+      symmetricKey.dispose();
+    }
+  }
+
+  /// Decrypts a [payload] using the supplied [keyPair].
+  static Future<Map<String, dynamic>> decrypt({
+    required LicensifyAsymmetricEncryptedPayload payload,
+    required LicensifyKeyPair keyPair,
+    String? implicitAssertion,
+  }) async {
+    LicensifySymmetricKey? symmetricKey;
+    try {
+      symmetricKey = await LicensifySymmetricKey.fromPaserkSeal(
+        paserk: payload.sealedKey,
+        keyPair: keyPair,
+      );
+
+      final crypto = _LicensifySymmetricCrypto(symmetricKey: symmetricKey);
+      return await crypto.decrypt(
+        payload.encryptedToken,
+        implicitAssertion: implicitAssertion,
+      );
+    } catch (e) {
+      throw Exception('Failed to decrypt data with the supplied key pair: $e');
+    } finally {
+      symmetricKey?.dispose();
+    }
+  }
+}

--- a/lib/src/crypto/licensify_asymmetric_crypto.dart
+++ b/lib/src/crypto/licensify_asymmetric_crypto.dart
@@ -104,7 +104,9 @@ abstract final class _LicensifyAsymmetricCrypto {
 
       final userFooter = decoded[_footerUserFooterField];
       if (userFooter != null && userFooter is! String) {
-        throw Exception('Encrypted token footer value must be a string when set');
+        throw Exception(
+          'Encrypted token footer value must be a string when set',
+        );
       }
 
       return (sealedKey, userFooter as String?);

--- a/lib/src/licensify.dart
+++ b/lib/src/licensify.dart
@@ -685,11 +685,58 @@ abstract interface class Licensify {
   }
 
   // ========================================
+  // 🔐 АСИММЕТРИЧНОЕ ШИФРОВАНИЕ ДАННЫХ
+  // ========================================
+
+  /// Шифрует данные на публичный ключ получателя с использованием `k4.seal`
+  ///
+  /// Метод генерирует одноразовый симметричный ключ, шифрует [data] в
+  /// PASETO `v4.local` токен и запечатывает этот ключ в PASERK `k4.seal`
+  /// при помощи [publicKey]. Получившийся контейнер можно передать получателю
+  /// и расшифровать только парой ключей, в которую входит соответствующий
+  /// приватный ключ.
+  ///
+  /// Возвращаемый [LicensifyAsymmetricEncryptedPayload] удобно сериализовать
+  /// через [LicensifyAsymmetricEncryptedPayload.toJson] и хранить вместе с
+  /// лицензиями или конфигурациями.
+  static Future<LicensifyAsymmetricEncryptedPayload> encryptDataForPublicKey({
+    required Map<String, dynamic> data,
+    required LicensifyPublicKey publicKey,
+    String? footer,
+    String? implicitAssertion,
+  }) async {
+    return await _LicensifyAsymmetricCrypto.encrypt(
+      data: data,
+      publicKey: publicKey,
+      footer: footer,
+      implicitAssertion: implicitAssertion,
+    );
+  }
+
+  /// Расшифровывает данные, зашифрованные на публичный ключ, используя
+  /// полноценную пару ключей [keyPair].
+  ///
+  /// Метод принимает [payload], полученный из
+  /// [encryptDataForPublicKey], восстанавливает одноразовый симметричный ключ
+  /// из `k4.seal` и возвращает исходный JSON с возможным `_footer`.
+  static Future<Map<String, dynamic>> decryptDataForKeyPair({
+    required LicensifyAsymmetricEncryptedPayload payload,
+    required LicensifyKeyPair keyPair,
+    String? implicitAssertion,
+  }) async {
+    return await _LicensifyAsymmetricCrypto.decrypt(
+      payload: payload,
+      keyPair: keyPair,
+      implicitAssertion: implicitAssertion,
+    );
+  }
+
+  // ========================================
   // 🛠️ ВСПОМОГАТЕЛЬНЫЕ МЕТОДЫ
   // ========================================
 
   /// Получает информацию о версии библиотеки
-  static const String version = '3.2.0';
+  static const String version = '4.3.0';
 
   /// Получает информацию о поддерживаемых версиях PASETO
   static const List<String> supportedPasetoVersions = ['v4.public', 'v4.local'];

--- a/lib/src/licensify.dart
+++ b/lib/src/licensify.dart
@@ -696,10 +696,9 @@ abstract interface class Licensify {
   /// и расшифровать только парой ключей, в которую входит соответствующий
   /// приватный ключ.
   ///
-  /// Возвращаемый [LicensifyAsymmetricEncryptedPayload] удобно сериализовать
-  /// через [LicensifyAsymmetricEncryptedPayload.toJson] и хранить вместе с
-  /// лицензиями или конфигурациями.
-  static Future<LicensifyAsymmetricEncryptedPayload> encryptDataForPublicKey({
+  /// Возвращаемый PASETO токен содержит `k4.seal` в footer, поэтому его можно
+  /// хранить и передавать как обычную строку.
+  static Future<String> encryptDataForPublicKey({
     required Map<String, dynamic> data,
     required LicensifyPublicKey publicKey,
     String? footer,
@@ -716,16 +715,16 @@ abstract interface class Licensify {
   /// Расшифровывает данные, зашифрованные на публичный ключ, используя
   /// полноценную пару ключей [keyPair].
   ///
-  /// Метод принимает [payload], полученный из
-  /// [encryptDataForPublicKey], восстанавливает одноразовый симметричный ключ
-  /// из `k4.seal` и возвращает исходный JSON с возможным `_footer`.
+  /// Метод принимает токен, полученный из [encryptDataForPublicKey],
+  /// восстанавливает одноразовый симметричный ключ из `k4.seal` внутри footer
+  /// и возвращает исходный JSON с `_footer`, если он задавался.
   static Future<Map<String, dynamic>> decryptDataForKeyPair({
-    required LicensifyAsymmetricEncryptedPayload payload,
+    required String encryptedToken,
     required LicensifyKeyPair keyPair,
     String? implicitAssertion,
   }) async {
     return await _LicensifyAsymmetricCrypto.decrypt(
-      payload: payload,
+      encryptedToken: encryptedToken,
       keyPair: keyPair,
       implicitAssertion: implicitAssertion,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: licensify
 description: A modern Dart library for secure license generation and validation using PASETO v4.
-version: 4.2.0
+version: 4.3.0
 homepage: https://github.com/nogipx/licensify
 repository: https://github.com/nogipx/licensify
 issue_tracker: https://github.com/nogipx/licensify/issues

--- a/test/explicit_keys_test.dart
+++ b/test/explicit_keys_test.dart
@@ -83,7 +83,9 @@ void main() {
         final segments = token.split('.');
         expect(segments.length, 4);
         final footerSegment = segments.last;
-        final footerJson = utf8.decode(base64Url.decode(footerSegment));
+        final footerJson = utf8.decode(
+          base64Url.decode(base64Url.normalize(footerSegment)),
+        );
         final footer = jsonDecode(footerJson) as Map<String, dynamic>;
         expect(footer['sealedKey'], isA<String>());
         expect(footer['sealedKey'], startsWith('k4.seal.'));

--- a/test/explicit_keys_test.dart
+++ b/test/explicit_keys_test.dart
@@ -65,7 +65,8 @@ void main() {
       }
     });
 
-    test('should seal data for a public key and decrypt with key pair', () async {
+    test('should seal data for a public key and decrypt with key pair',
+        () async {
       final keyPair = await Licensify.generateSigningKeys();
       final data = {
         'user_id': 'test123',


### PR DESCRIPTION
## Summary
- add an asymmetric encryption container and helpers backed by PASERK k4.seal
- expose Licensify.encryptDataForPublicKey/decryptDataForKeyPair and document their usage
- extend examples, tests, and version metadata for the new API

## Testing
- not run (Dart SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f2c798a658833396dea8df8d72938e